### PR TITLE
wait for data ready

### DIFF
--- a/sht31.py
+++ b/sht31.py
@@ -1,4 +1,5 @@
 from machine import I2C
+import time
 
 R_HIGH   = const(1)
 R_MEDIUM = const(2)
@@ -57,6 +58,7 @@ class SHT31(object):
         if r not in (R_HIGH, R_MEDIUM, R_LOW):
             raise ValueError('Wrong repeatabillity value given!')
         self._send(self._map_cs_r[cs][r])
+        time.sleep_ms(50)
         raw = self._recv(6)
         return (raw[0] << 8) + raw[1], (raw[3] << 8) + raw[4]
 


### PR DESCRIPTION
SHT31 will take about 12.5ms to get data ready at High repeatability Mode, if read too early, the I2C module will report `OSError: I2C bus error`, so delay a while to read will fix the issue. 
It may be a bug in I2C module, while SCL pulled low, I2C should wait for change.